### PR TITLE
[GRIFFIN] BoardConfig: Allow overriding TARGET_NEEDS_DTBOIMAGE in customization

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -43,5 +43,5 @@ BOARD_DTBOIMG_PARTITION_SIZE := 8388608
 ifneq ($(TARGET_COMPILE_WITH_MSM_KERNEL),true)
 BOARD_PREBUILT_DTBOIMAGE := kernel/sony/msm-4.14/common-kernel/dtbo-griffin.img
 else
-TARGET_NEEDS_DTBOIMAGE := true
+TARGET_NEEDS_DTBOIMAGE ?= true
 endif


### PR DESCRIPTION
Allowing to override this env variable allows to successfully
build the kernel in-line on most custom ROMs using their own
kernel building makefiles.