### PR TITLE
[GRIFFIN] vendor: NFC: Disable debug mode, add RF params for PN557 chip

### DIFF
--- a/rootdir/vendor/etc/libnfc-nxp.conf
+++ b/rootdir/vendor/etc/libnfc-nxp.conf
@@ -6,13 +6,13 @@
 # ANDROID_LOG_WARN           0x02
 # ANDROID_LOG_ERROR          0x01
 # ANDROID_LOG_SILENT         0x00
-NXPLOG_EXTNS_LOGLEVEL=0x03
-NXPLOG_NCIHAL_LOGLEVEL=0x03
-NXPLOG_NCIX_LOGLEVEL=0x03
-NXPLOG_NCIR_LOGLEVEL=0x03
-NXPLOG_FWDNLD_LOGLEVEL=0x03
-NXPLOG_TML_LOGLEVEL=0x03
-NFC_DEBUG_ENABLED=0x01
+NXPLOG_EXTNS_LOGLEVEL=0x01
+NXPLOG_NCIHAL_LOGLEVEL=0x01
+NXPLOG_NCIX_LOGLEVEL=0x01
+NXPLOG_NCIR_LOGLEVEL=0x01
+NXPLOG_FWDNLD_LOGLEVEL=0x01
+NXPLOG_TML_LOGLEVEL=0x01
+NFC_DEBUG_ENABLED=0x00
 
 ###############################################################################
 # Nfc Device Node name
@@ -389,4 +389,311 @@ PRESENCE_CHECK_ALGORITHM=2
 # Extended APDU length for ISO_DEP
 ISO_DEP_MAX_TRANSCEIVE=0xFEFF
 
+###############################################################################
+#RF CONFIG
+###############################################################################
+NXP_RF_CONF_BLK_1={
+	20, 02, FA, 1F,
+	A0, 35, 01, 00,
+	A0, 0D, 03, 00, 43, A0,
+	A0, 0D, 04, 00, 42, FF, FF,
+	A0, 0D, 06, 04, 44, 00, 08, F6, 00,
+	A0, 0D, 06, 04, 45, 80, 40, 00, 00,
+	A0, 0D, 06, 04, 4A, 00, 00, 00, 00,
+	A0, 0D, 03, 04, 47, 00,
+	A0, 0D, 06, 04, 35, 00, 3E, 00, 00,
+	A0, 0D, 06, 04, 33, 0F, 40, 04, 00,
+	A0, 0D, 03, 04, 40, 00,
+	A0, 0D, 06, 06, 35, F5, 05, 80, 01,
+	A0, 0D, 06, 06, 42, F8, 40, FF, FF,
+	A0, 0D, 06, C2, 35, 00, 3E, 00, 03,
+	A0, 0D, 06, C2, 34, F7, 7F, 10, 08,
+	A0, 0D, 06, C2, 33, 03, 40, 04, 80,
+	A0, 0D, 06, 08, 2D, 0D, 25, 2C, 01,
+	A0, 0D, 06, 08, 44, 04, 04, C4, 00,
+	A0, 0D, 06, 08, 30, 70, 00, 18, 00,
+	A0, 0D, 06, 08, 45, 83, 60, 40, 05,
+	A0, 0D, 06, 08, 42, 00, 00, FF, FF,
+	A0, 0D, 06, 08, 16, AE, 00, 1F, 00,
+	A0, 0D, 03, 08, 15, 00,
+	A0, 0D, 06, 08, 37, 28, 76, 00, 00,
+	A0, 0D, 06, 09, 30, 00, 00, 00, 00,
+	A0, 0D, 06, 09, 37, 00, 00, 00, 00,
+	A0, 0D, 06, 09, 42, 01, 10, FF, FF,
+	A0, 0D, 03, 72, 03, 3D,
+	A0, 0D, 04, 72, 42, F8, 40,
+	A0, 0D, 03, 72, 16, 19,
+	A0, 0D, 03, 72, 15, 01,
+	A0, 0D, 06, 72, 4A, 53, 07, 00, 1B
+}
+
+NXP_RF_CONF_BLK_2={
+	20, 02, FB, 22,
+	A0, 0D, 03, 72, 0D, 26,
+	A0, 0D, 03, 72, 14, 26,
+	A0, 0D, 06, 3C, 2D, DC, 40, 04, 00,
+	A0, 0D, 06, 3C, 44, 66, 0A, 00, 00,
+	A0, 0D, 06, 74, 4A, 56, 07, 01, 1B,
+	A0, 0D, 04, 74, 42, 68, 40,
+	A0, 0D, 03, 74, 16, 00,
+	A0, 0D, 03, 74, 15, 00,
+	A0, 0D, 03, 74, 0D, 11,
+	A0, 0D, 03, 74, 14, 11,
+	A0, 0D, 06, 3E, 2D, 05, 35, 1E, 01,
+	A0, 0D, 06, 3E, 44, 65, 09, 00, 00,
+	A0, 0D, 06, 76, 4A, 56, 07, 01, 1B,
+	A0, 0D, 04, 76, 42, 68, 40,
+	A0, 0D, 03, 76, 16, 00,
+	A0, 0D, 03, 76, 15, 00,
+	A0, 0D, 03, 76, 0D, 08,
+	A0, 0D, 03, 76, 14, 08,
+	A0, 0D, 06, 40, 2D, 05, 45, 1E, 01,
+	A0, 0D, 06, 40, 44, 65, 09, 00, 00,
+	A0, 0D, 04, 78, 42, F0, 40,
+	A0, 0D, 06, 78, 4A, 11, 07, 01, 1B,
+	A0, 0D, 03, 78, 16, 00,
+	A0, 0D, 03, 78, 15, 00,
+	A0, 0D, 03, 78, 0D, 04,
+	A0, 0D, 03, 78, 14, 04,
+	A0, 0D, 06, 4C, 44, 65, 0A, 00, 00,
+	A0, 0D, 06, 4C, 2D, 15, 34, 1F, 01,
+	A0, 0D, 06, 82, 4A, 34, 07, 00, 07,
+	A0, 0D, 04, 82, 42, 70, 40,
+	A0, 0D, 06, 82, 0F, 6C, 01, 04, 00,
+	A0, 0D, 03, 82, 16, 00,
+	A0, 0D, 03, 82, 15, 00,
+	A0, 0D, 06, 4E, 44, 65, 09, 00, 00
+}
+
+# 2403 : FDT setting for Target A106k . The value means 1/fc(1 clock) and it can set between 0x00 to 0xFF.
+# 5E44 : Rx HPF / Rx Gain for F212
+# 9442 : Tx modulation index for F212 (refer to register setting guide)
+NXP_RF_CONF_BLK_3={
+	20, 02, FB, 21,
+	A0, 0D, 06, 4E, 2D, 05, 35, 1E, 01,
+	A0, 0D, 06, 84, 4A, 43, 07, 01, 07,
+	A0, 0D, 04, 84, 42, 70, 40,
+	A0, 0D, 03, 84, 16, 00,
+	A0, 0D, 03, 84, 15, 00,
+	A0, 0D, 06, 50, 44, 65, 09, 00, 00,
+	A0, 0D, 06, 50, 2D, 05, 35, 1E, 01,
+	A0, 0D, 06, 86, 4A, 32, 07, 01, 07,
+	A0, 0D, 04, 86, 42, 70, 40,
+	A0, 0D, 03, 86, 16, 00,
+	A0, 0D, 03, 86, 15, 00,
+	A0, 0D, 06, 5E, 2D, 0D, 48, 0C, 01,
+	A0, 0D, 06, 5E, 44, 55, 08, 00, 00,
+	A0, 0D, 06, 60, 2D, 0D, 5A, 0C, 01,
+	A0, 0D, 06, 60, 44, 55, 08, 00, 00,
+	A0, 0D, 04, 94, 42, 78, 40,
+	A0, 0D, 06, 94, 4A, 43, 07, 00, 07,
+	A0, 0D, 03, 94, 16, 00,
+	A0, 0D, 03, 94, 15, 00,
+	A0, 0D, 04, 96, 42, 88, 40,
+	A0, 0D, 06, 96, 4A, 11, 07, 01, 07,
+	A0, 0D, 03, 96, 16, 00,
+	A0, 0D, 03, 96, 15, 00,
+	A0, 0D, 06, 1C, 44, 05, 04, C4, 00,
+	A0, 0D, 03, 24, 03, 7D,
+	A0, 0D, 06, 70, 16, 8E, 00, 1F, 00,
+	A0, 0D, 03, 28, 16, 00,
+	A0, 0D, 03, 2C, 16, 00,
+	A0, 0D, 06, 34, 44, 04, 04, C4, 00,
+	A0, 0D, 06, 36, 30, E0, 00, 30, 00,
+	A0, 0D, 03, 36, 45, 70,
+	A0, 0D, 03, 37, 45, 60,
+	A0, 0D, 06, 38, 30, 40, 00, 20, 00
+}
+
+NXP_RF_CONF_BLK_4={
+	20, 02, FA, 1E,
+	A0, 0D, 06, 38, 44, 02, 04, C4, 00,
+	A0, 0D, 06, 3A, 30, 26, 00, 08, 00,
+	A0, 0D, 06, 3A, 44, 11, 00, C4, 00,
+	A0, 0D, 06, 44, 30, 70, 00, 18, 00,
+	A0, 0D, 06, 44, 44, 04, 04, C4, 00,
+	A0, 0D, 06, 46, 30, B0, 00, 45, 00,
+	A0, 0D, 06, 48, 30, B0, 00, 45, 00,
+	A0, 0D, 06, 4A, 30, 70, 00, 18, 00,
+	A0, 0D, 03, 56, 30, 00,
+	A0, 0D, 06, 0C, 45, C3, 82, 71, 05,
+	A0, 0D, 03, 10, 44, 60,
+	A0, 0D, 06, 10, 30, 70, 00, 18, 00,
+	A0, 0D, 03, 10, 48, 10,
+	A0, 0D, 06, 10, 45, 80, 40, 00, 00,
+	A0, 0D, 06, 10, 2D, 0D, 25, 2C, 01,
+	A0, 0D, 03, 10, 35, 0C,
+	A0, 0D, 06, 11, 30, 00, 00, 00, 00,
+	A0, 0D, 03, 11, 48, 00,
+	A0, 0D, 06, 11, 85, 00, 00, 00, 00,
+	A0, 0D, 06, 22, 44, 05, 04, C4, 00,
+	A0, 0D, 06, 62, 44, 04, 04, C4, 00,
+	A0, 0D, 03, 12, 16, 00,
+	A0, 0D, 06, 12, 37, 00, 00, 00, 00,
+	A0, 0D, 03, 12, 35, 0C,
+	A0, 0D, 06, CC, 42, F8, 40, FF, FF,
+	A0, 0D, 06, CC, 4A, 53, 07, 00, 1B,
+	A0, 0D, 06, CE, 42, 78, 40, FF, FF,
+	A0, 0D, 06, CE, 4A, 43, 07, 00, 07,
+	A0, 0D, 06, D0, 42, 88, 40, FF, FF,
+	A0, 0D, 06, D0, 4A, 11, 07, 01, 07
+}
+
+# A038 : define RF detect level(CLIF_ANA_NFCLD_REG)
+#	A03804[TH of external RF-on][TH of external RF-off][TH of Target Passive&Active][0x00 => Apply RSSI Interpolation algo// 0x01 => RSSI is either raw ADC or AGC]
+# A03A : LM Phase setting
+#	A03A08[Common(2byte by little endian)][TypeA(2byte by little endian)][TypeB(2byte by little endian)][TypeF(2byte by little endian)]
+# A09C : RF detect level for ONLY FeliCa CE
+#	A09C02[TH of RSSI by little-endian(2byte)]
+# A0A9 : DLMA_TX settings (this value should be copied form DLMA debug conf) ######DO NOT USE A034 PARAMETER FOR 12.01.03 or OLDER FW######
+NXP_RF_CONF_BLK_5={
+	20, 02, F3, 0D,
+	A0, 0D, 03, 98, 16, 01,
+	A0, 0D, 03, 98, 15, 01,
+	A0, 0D, 03, 9A, 16, 00,
+	A0, 0D, 03, 9A, 15, 00,
+	A0, 0D, 03, 9C, 16, 00,
+	A0, 0D, 03, 9C, 15, 00,
+	A0, 0D, 04, CA, 42, 70, 40,
+	A0, 0D, 06, CA, 44, 65, 0A, 00, 00,
+	A0, 0D, 06, CA, 2D, 15, 34, 1F, 01,
+	A0, 0D, 03, A6, 41, 82,
+	A0, 38, 04, 14, 0B, 0B, 00,
+	A0, 9C, 02, 20, 00,
+	A0, A9, A0, 00, C1, 00, 0A, 01, 80, 41, 0A, 02, 81, 83, 0A, 03, C0, 42, 06, 04, 80, 46, 06, 05, C3, 01, 03, 06, C2, 05, 03, 07, C2, 4A, 03, 07, 81, 01, 01, 08, C3, 8B, 03, 08, C3, 05, 01, 09, C3, 92, 03, 09, C6, 84, 01, 0A, C4, CC, 03, 0A, C6, 89, 01, 0B, C5, D4, 03, 0B, C7, 92, 01, 0C, 44, 00, 03, 0C, C7, C6, 01, 0D, 42, 04, 03, 0D, C9, CE, 01, 0E, 42, 48, 03, 0E, 03, 00, 01, 0F, 43, 50, 03, 0F, 43, 04, 01, 10, 43, 91, 03, 10, 45, 0A, 01, 11, 44, 95, 03, 11, 46, 11, 01, 12, 46, 8E, 01, 13, 47, C5, 01, 14, 48, CC, 01, 15, 4B, D4, 01, 16, 4E, D7, 01, 17, 45, A2, 01, 18, 46, A6, 01, 19, 46, AE, 01, 1A, 47, B4, 01, 1B, 48, EA, 01, 1C, 49, F0, 01
+}
+
+# A029 : Card Mode settings in PHONE OFF for "PLL clock" (refer to refer register setting guidelines)
+# A034 : DLMA_RSSI settings (this value should be copied form DLMA debug conf) ######DO NOT USE A034 PARAMETER FOR 12.01.03 or OLDER FW######
+# A0AF : DLMA CTRL settings (this value should be copied form DLMA debug conf)
+NXP_RF_CONF_BLK_6={
+	20, 02, C1, 03,
+	A0, 29, 17, 1A, 07, 00, 1D, 00, 02, 00, 1D, 00, 02, 00, 40, F1, F1, 00, 40, F1, F1, 38, 70, 00, 00, 00,
+	A0, 34, 94, 23, 04, 18, CB, 00, 00, CB, 00, 00, CB, 00, 00, 34, 01, 00, 34, 01, 00, 34, 01, 00, 34, 01, 00, 34, 01, 00, 34, 01, 00, A4, 01, 00, A4, 01, 00, A4, 01, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, 18, 2C, 01, 00, 2C, 01, 00, 2C, 01, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, DC, 05, 00, 
+	A0, AF, 0C, 83, C8, 8F, 10, 00, 83, 94, 9D, 10, 00, 77, 08
+}
+
+###########################################################################################
+# NXP_CORE_CONF_EXTN group
+#
+# A002 : related Clock setting
+#	(If you have set "NXP_SYS_CLK_FREQ_SEL" and "NXP_SYS_CLK_SRC_SEL", it is not necessary to set this parameter.)
+# A003 : Clock setting
+#	(If you have set "NXP_SYS_CLK_FREQ_SEL" and "NXP_SYS_CLK_SRC_SEL", it is not necessary to set this parameter.)
+# A004 : Timeout for clock [TimeOut(us)=1200+(value)*330] 1.53ms to 10 ms in steps of 330us
+# A007 : Related Low Power Mode (should be 0x03)
+# A008 : PbF setting (PN557's GPIO setting)
+# A00B : DPC (Refer to UserManual)
+# A018 : AGC Compensation setting
+#	(The parameter is generated from "PN81T PN557 AgcPhaseCompensation.xls".)
+# A037 : RFCLD setting (Refer to USER Manual)
+# A03A : LM Phase setting 
+#	A03A08[Common(2byte by little endian)][TypeA(2byte by little endian)][TypeB(2byte by little endian)][TypeF(2byte by little endian)]
+# A040 : Tag Detector function
+#	0x00:disable(=Normal-pol mode)
+#	0x01:Hybrid
+#	0x05:Hybrid with TypeA only pol
+#	0x09:Hybrid with fake detection report
+#	0x81:Hybrid with Trace mode
+# A041 : AGC Threshold of Tag Detector function
+# A043 : Number of pulse in Hybrid mode of Tag Detector function
+#	If you will use too large value, then it will work as LPS(LPP).
+# A05E : 0x01 => RID is sent on RF to the T1T
+#		 0x00 => RID is NOT sent on RF to the T1T
+#	This parameter will used for NCI 1.0
+#	For NCI 2.0, the RID is sent on RF anyway.
+# A081 : 0x00=NFC Forum mode / 0x01=EMVCo mode
+#	(It is necessary to set the value to 0x01 because DTA apk changes the value to 0x00)
+# A086 : Set to 0x77 for symmetric baud rate between UICC's
+# A0AA : RextGain RextAGC value
+#		Rext=560ohm		A0, AA, 04, FD, 03, 30, 02,
+#		Rext=1kohm		A0, AA, 04, 03, 04, E8, 03,
+#		Rext=1.3kohm	A0, AA, 04, 1A, 04, 14, 05,
+#		Rext=2.2kohm	A0, AA, 04, 38, 04, 98, 08,
+#		Rext=3.3kohm	A0, AA, 04, 42, 04, E4, 0C,
+#		Rext=5.6kohm	A0, AA, 04, 56, 04, E0, 15,
+#	## Please note the above value of xxxx in A0AAxxxxyyyy is reference value.
+#	## Each models shall be adjusted the value by verifying linearity of RSSI-field power using ISO10373 test bench.
+# A0D1 : SWP interface1_2 (UICC2) Bitrate 0x04=912kbps, 0x06=1250kbps, 0x07=1667kbps
+# A0D4 : SWP interface1_2 (UICC2) enable(0x01)/disable(0x00)
+# A0DD : ?
+# A0EC : SWP interface1_1 (UICC1) enable(0x01)/disable(0x00)
+# A0ED : SWP interface2 (eSE) enable(0x01)/disable(0x00)
+###############################################################################
+# Core configuration extensions
+# It includes
+# Wired mode settings A0ED, A0EE
+# Tag Detector A040, A041, A043
+# Low Power mode A007
+# Clock settings A002, A003
+# PbF settings A008
+# Clock timeout settings A004
+# ADD Phase control (No Setting)
+# 5.6k E015
+#
+# 0837 Tx mode1,2,3 for CE A&B Value[x8760000] x=2:mode1 x=0:mode2 x=4:mode3
+# 0842 Tx setting for Target passive mode
+# 7216 UnderShoot setting for initiator A106k (refer to register setting guidelines)
+# C235 AGC_INPUT_REG (refer to register setting guidelines)
+NXP_CORE_CONF_EXTN={20, 02, BE, 14,
+    A0, EC, 01, 01,
+    A0, ED, 01, 00,
+    A0, 5E, 01, 01,
+    A0, 12, 01, 02,
+    A0, 18, 08, 6D, 04, 7B, 02, 1E, FC, 26, 02,
+    A0, 40, 01, 01,
+    A0, 41, 01, 03,
+    A0, 43, 01, 00,
+    A0, DD, 01, 2D,
+    A0, D1, 01, 02,
+    A0, D4, 01, 00,
+    A0, 37, 01, 11,
+    A0, 07, 01, 03,
+    A0, AA, 04, 90, 01, 98, 08,
+    A0, 08, 02, 00, 00,
+    A0, 0B, 57,
+    11, 11, 90, 78, 0F, 4E, 00, 3D, 95, 00, 00, 3D, 9F, 00, 00, 50,
+    9F, 00, 00, 59, 9F, 00, 00, 5A, 9F, 00, 00, 64, 9F, 00, 00, 65,
+    9F, 00, 00, 6E, 9F, 00, 00, 72, 9F, 00, 00, 79, 9F, 00, 00, 7B,
+    9F, 00, 00, 84, 9F, 00, 00, 86, 9F, 00, 00, 8F, 9F, 00, 00, 91,
+    9F, 00, 00, 9A, 9F, 00, 00, A1, 9F, 00, 00, A7, 9F, 00, 00, B0,
+    1F, 00, 00, B9, 1F, 00, 00,
+    A0, 1F, 06, AB, 2F, 29, 13, 63, 00,
+    A0, 3A, 08, 0E, 01, 0E, 01, 0E, 01, 3C, 00,
+    A0, 81, 01, 01,
+    A0, 86, 01, 77
+}
+
+#    A0, 1D, 02, 80, 00,
+#    A0, B1, 02, E0, 15
+#       A0, F2, 01, 01,
+#       A0, 40, 01, 01,
+#       A0, 41, 01, 02, LPP Threshu
+#       A0, 43, 01, 04,
+#       A0, 02, 01, 01,
+#       A0, 03, 01, 11,
+#       A0, 07, 01, 03,
+#       A0, 08, 01, 01
+#       }
+
+###############################################################################
+# Core configuration settings
+#0x082 = 130
+NXP_CORE_CONF={ 20, 02, 2D, 0F,
+        28, 01, 00,
+        21, 01, 00,
+        30, 01, 08,
+        31, 01, 03,
+        32, 01, 60,
+        38, 01, 01,
+        33, 00,
+        54, 01, 06,
+        50, 01, 02,
+        5B, 01, 00,
+        80, 01, 01,
+        81, 01, 01,
+        82, 01, 0E,
+        18, 01, 01,
+        85, 01, 01
+        }
 ###############################################################################


### PR DESCRIPTION
The NFC configuration activates "godmode" debugging, which is
totally unnecessary and clutters the Android logs for literally
no reason (since it works.. there's nothing to debug).

Also, add the RF configuration from Sony, in order to stay
compliant and to ensure correct functionality of our NFC chip
with our NFC antenna.

Tested on SoMC SM8150 Kumano Griffin DSDS