### PR TITLE
[GRIFFIN] device: Set XXXHDPI as preferred, change density to 630dpi

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -79,11 +79,11 @@ PRODUCT_PACKAGES += \
     TransPowerSensors
 
 PRODUCT_AAPT_CONFIG := normal
-PRODUCT_AAPT_PREBUILT_DPI := xxhdpi xhdpi hdpi
-PRODUCT_AAPT_PREF_CONFIG := xxhdpi
+PRODUCT_AAPT_PREBUILT_DPI := xxxhdpi xxhdpi xhdpi hdpi
+PRODUCT_AAPT_PREF_CONFIG := xxxhdpi
 
 PRODUCT_PROPERTY_OVERRIDES := \
-    ro.sf.lcd_density=420 \
+    ro.sf.lcd_density=630 \
     ro.usb.pid_suffix=205
 
 # Inherit from those products. Most specific first.


### PR DESCRIPTION
Set XXXHDPI as preferred config and change the display
density to 630DPI to allow a good UI size now that we have
switched this device to its panel native "4k" (1644x3840)
resolution.

P.S.: An extract from Google's display densities guide:
xxhdpi	Resources for extra-extra-high-density (xxhdpi) screens (~480dpi).
xxxhdpi	Resources for extra-extra-extra-high-density (xxxhdpi) uses (~640dpi).


Depends on https://github.com/sonyxperiadev/kernel/pull/2245